### PR TITLE
feat: add Rust (rust2cpg) frontend support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 # Joern CLI container for CPG generation and caching.
-FROM eclipse-temurin:21-jdk-jammy
+# NOTE: base image is noble (Ubuntu 24.04, glibc 2.39), NOT jammy (22.04,
+# glibc 2.35). rust2cpg's native astgen binary (rust_ast_gen-linux) is linked
+# against GLIBC_2.39 and fails on jammy with "version `GLIBC_2.39' not found",
+# silently yielding an empty Rust CPG. glibc is backward-compatible, so every
+# other frontend's native astgen keeps working on noble.
+FROM eclipse-temurin:21-jdk-noble
 
 RUN apt-get update && apt-get install -y \
     curl \
@@ -20,9 +25,18 @@ RUN mkdir -p ${JOERN_HOME} && \
 
 ENV PATH="${JOERN_HOME}/joern-cli:${JOERN_HOME}/joern-cli/bin:${PATH}"
 
+# Rust toolchain — rust2cpg's native astgen loads the crate by shelling out to
+# `cargo`/`rustc` (it errors "Are `cargo` and `rustc` on your PATH?" otherwise),
+# so without them every Rust CPG comes out empty. The minimal profile installs
+# just rustc + cargo (no docs/clippy/rustfmt) to keep the layer small.
+ENV RUSTUP_HOME=/opt/rustup \
+    CARGO_HOME=/opt/cargo
+RUN curl -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable
+ENV PATH="/opt/cargo/bin:${PATH}"
+
 RUN mkdir -p /playground
 
-RUN joern --help
+RUN joern --help && rustc --version && cargo --version
 
 RUN echo '#!/bin/bash\n\
 set -e\n\

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -73,6 +73,7 @@ cpg:
     - php
     - ruby
     - swift
+    - rust
   # NOTE: every token below is anchored with a leading `(?:^|.*/)` boundary
   # (start-of-string OR a literal `/`). `--exclude-regex` matching semantics
   # differ by frontend: JVM frontends (c2cpg, javasrc2cpg, pysrc2cpg, ...)
@@ -222,6 +223,10 @@ cpg:
     - swift
     - jimple
     - ghidra
+    # rust OMITTED (like go): rust2cpg matches --exclude-regex against
+    # cargo-resolved paths, so the default exclusion_patterns collapse the CPG
+    # to 0 methods. Rust stays in supported_languages; it is built without
+    # exclusions.
 
   taint_sources:
     c:

--- a/src/defaults.py
+++ b/src/defaults.py
@@ -101,9 +101,14 @@ OUTPUT_TRUNCATION_LENGTH = 2000
 
 SUPPORTED_LANGUAGES = [
     "java", "c", "cpp", "javascript", "python", "go",
-    "kotlin", "csharp", "ghidra", "jimple", "php", "ruby", "swift"
+    "kotlin", "csharp", "ghidra", "jimple", "php", "ruby", "swift",
+    "rust"
 ]
 
+# rust OMITTED (like go): rust2cpg loads the crate through cargo and matches
+# --exclude-regex against the resolved file paths, and the default
+# exclusion_patterns were observed to collapse a Rust CPG to 0 methods.
+# Rust stays in SUPPORTED_LANGUAGES; it is just built without exclusions.
 LANGUAGES_WITH_EXCLUSIONS = [
     "c", "cpp", "java", "javascript", "python", "go",
     "kotlin", "csharp", "php", "ruby"
@@ -334,6 +339,7 @@ FRONTEND_CAPABILITIES = {
     "rubysrc2cpg":     {"exclude_regex"},
     "jimple2cpg":      {"exclude_regex"},
     "ghidra2cpg":      {"exclude_regex"},
+    "rust2cpg":        {"exclude_regex"},
 }
 
 # Capability every frontend has, used as the safe fallback for unknown binaries.
@@ -353,6 +359,7 @@ LANGUAGE_COMMANDS = {
     "php":        "/opt/joern/joern-cli/php2cpg",
     "ruby":       "/opt/joern/joern-cli/rubysrc2cpg",
     "swift":      "/opt/joern/joern-cli/swiftsrc2cpg.sh",
+    "rust":       "/opt/joern/joern-cli/rust2cpg",
 }
 
 
@@ -386,6 +393,7 @@ SCOPE_SOURCE_EXTENSIONS = {
     "php":        ["php", "phtml", "php3", "php4", "php5"],
     "ruby":       ["rb"],
     "swift":      ["swift"],
+    "rust":       ["rs"],
 }
 
 # Default file extension per language, used to name a pasted code snippet
@@ -403,6 +411,7 @@ LANGUAGE_EXTENSIONS = {
     "php":        "php",
     "ruby":       "rb",
     "swift":      "swift",
+    "rust":       "rs",
 }
 
 # Upper bound on a pasted code snippet (source_type="snippet"). Snippets are meant

--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -38,6 +38,7 @@ SUPPORTED_LANGUAGES = [
     "php",
     "ruby",
     "swift",
+    "rust",
 ]
 
 
@@ -258,6 +259,11 @@ _LANG_SIGNALS = {
     "swift": [
         (r"\bguard\b", 2), (r"\bimport\s+Swift", 3), (r"\bfunc\s+\w+\s*\(", 1),
         (r"\blet\s+\w+", 1), (r"\bvar\s+\w+\s*:", 1),
+    ],
+    "rust": [
+        (r"\bfn\s+\w+\s*\(", 2), (r"\blet\s+mut\b", 3), (r"\w+!\s*\(", 2),
+        (r"\buse\s+std::", 3), (r"->\s*\w", 1), (r"\bimpl\b", 2),
+        (r"#\[\w+", 2), (r"::\w", 1),
     ],
 }
 _LANG_SIGNALS_COMPILED = {

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -190,10 +190,10 @@ class TestValidateLanguage:
     def test_invalid_language(self):
         """Test invalid programming language"""
         with pytest.raises(ValidationError) as exc_info:
-            validate_language("rust")
+            validate_language("cobol")
 
         msg = str(exc_info.value)
-        assert "Unsupported language 'rust'" in msg
+        assert "Unsupported language 'cobol'" in msg
         # The message must list the accepted ids so the caller can self-correct.
         assert "java" in msg and "swift" in msg
 


### PR DESCRIPTION
## Summary

Joern `4.0.581` ships **`rust2cpg`**. This wires Rust into codebadger's language registry and satisfies the two frontend-specific runtime requirements needed for a real (non-empty) Rust CPG. Verified end-to-end: `rust2cpg` on a minimal crate produces a CPG with the expected user methods (`add`, `greet`, `main`).

## Registry wiring (`src/defaults.py`, `src/utils/validators.py`, `config.example.yaml`)

- `SUPPORTED_LANGUAGES` += `rust` (both the `defaults.py` and `validators.py` copies, and `config.example.yaml`)
- `LANGUAGE_COMMANDS`: `rust` → `/opt/joern/joern-cli/rust2cpg`
- `FRONTEND_CAPABILITIES`: `rust2cpg` → `{exclude_regex}` (its `--help` exposes only `--exclude`/`--exclude-regex`)
- `LANGUAGE_EXTENSIONS` / `SCOPE_SOURCE_EXTENSIONS`: `rust` → `rs`
- Snippet language-inference signals for Rust (`fn`, `let mut`, macros, `use std::`, `impl`, `#[...]`, `::`)

## Image changes (`Dockerfile`)

Both were required to get a non-empty CPG, and both are verified in the rebuilt image:

1. **Base image `eclipse-temurin:21-jdk-jammy` → `:21-jdk-noble`.** `rust2cpg`'s native astgen (`rust_ast_gen-linux`) is linked against **GLIBC_2.39**; jammy (Ubuntu 22.04) ships glibc 2.35, so it fails with `` version `GLIBC_2.39' not found `` and silently yields an empty CPG. noble (24.04) ships glibc 2.39. glibc is backward-compatible, so every other frontend's native astgen keeps working.
2. **Install the Rust toolchain** (`rustup`, minimal profile → `rustc` + `cargo`). `rust2cpg`'s astgen loads the crate by shelling out to `cargo`/`rustc` and errors (`Are cargo and rustc on your PATH?`) without them. `docker exec` inherits the image `ENV PATH`, so the frontend finds the toolchain at build time.

## Notable decision: Rust is omitted from `languages_with_exclusions`

Exactly like **Go** already is. `rust2cpg` matches `--exclude-regex` against cargo-resolved paths, and the default `exclusion_patterns` were observed to collapse a Rust CPG to **0 methods**. Rust stays in `supported_languages` and builds fine — just without exclusion filtering.

## ABAP (`abap2cpg`) — evaluated, left out

`abap2cpg` is the other frontend new to `4.0.581`. Its native `abapgen` expects a specific serialized ABAP format and rejected ordinary hand-written ABAP (`No ABAP files were parsed`), so support couldn't be verified. Happy to add it in a follow-up given real ABAP sources to test against.

## Verification

- New image: `glibc 2.39`, `cargo 1.97.0`, `rustc 1.97.0`, `JOERN_VERSION=4.0.581`.
- `rust2cpg` on a demo crate (loaded into Joern) → `<global>, add, greet, main`.
- `tests/test_validators.py` (123) and `tests/test_cpg_generator.py` + `tests/test_build_scoping.py` (29) pass. (The unrelated pre-existing `RichHandler` collection errors in other test modules are an environment/`rich`-version issue, not from this change.)

> Note: `config.yaml` (gitignored runtime config) was updated locally the same way; only tracked files are in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)