### PR TITLE
bump version to v0.6.2-beta

### DIFF
--- a/main.py
+++ b/main.py
@@ -56,7 +56,7 @@ from src.utils.postgres_db_manager import PostgresDBManager
 from src.defaults import resolve_database_url, resolve_redis_url
 from src.tools import register_tools
 
-VERSION = "0.6.1-beta"
+VERSION = "0.6.2-beta"
 
 services = {}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "codebadger"
-version = "0.6.1b0"
+version = "0.6.2b0"
 description = "Containerized MCP server exposing Joern Code Property Graphs for program and vulnerability analysis."
 readme = "README.md"
 requires-python = ">=3.10"  # PEP 604 union syntax (str | None) is used throughout

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """CodeBadger Server - A Model Context Protocol server for static code analysis using Joern."""
 
-__version__ = "0.6.1-beta"
+__version__ = "0.6.2-beta"
 __author__ = "Ahmed Lekssays"
 __email__ = "ahmed@lekssays.com"
 


### PR DESCRIPTION
Bumps codebadger from `0.6.1-beta` → `0.6.2-beta` across all three version references:

- `pyproject.toml` (`0.6.1b0` → `0.6.2b0`)
- `src/__init__.py` (`__version__`)
- `main.py` (`VERSION`)

Covers the changes merged since 0.6.1-beta: the exclude-regex anchoring fix (#23/#24) and Rust frontend support (#25, incl. the noble base image + Joern 4.0.581 + Rust toolchain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)